### PR TITLE
Mandatory final

### DIFF
--- a/builtins/cd.c
+++ b/builtins/cd.c
@@ -25,9 +25,7 @@ int	cd(char **args, t_env *minienv)
 	char	*oldpwd;
 	char	cwd[PATH_MAX];
 
-	if (!args[1])
-		return (EXIT_SUCCESS);
-	if (args[2])
+	if (args[1] && args[2])
 		return (cd_error());
 	if (args[1] && !str_equal(args[1], "~"))
 		path = args[1];

--- a/builtins/cd.c
+++ b/builtins/cd.c
@@ -3,21 +3,32 @@
 /*                                                        :::      ::::::::   */
 /*   cd.c                                               :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: lalex-ku <lalex-ku@42sp.org.br>            +#+  +:+       +#+        */
+/*   By: sguilher <sguilher@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/05/12 14:03:41 by lalex-ku          #+#    #+#             */
-/*   Updated: 2022/06/24 20:14:19 by lalex-ku         ###   ########.fr       */
+/*   Updated: 2022/06/26 21:05:41 by sguilher         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minishell.h"
 
+int	cd_error(void)
+{
+	print_error_msg("cd", "too many arguments");
+	return (EXIT_FAILURE);
+}
+
 int	cd(char **args, t_env *minienv)
 {
 	char	*path;
 	char	*pwd;
+	char	*oldpwd;
 	char	cwd[PATH_MAX];
 
+	if (!args[1])
+		return (EXIT_SUCCESS);
+	if (args[2])
+		return (cd_error());
 	if (args[1] && !str_equal(args[1], "~"))
 		path = args[1];
 	else
@@ -28,7 +39,8 @@ int	cd(char **args, t_env *minienv)
 		return (EXIT_FAILURE);
 	}
 	pwd = minienv_value("PWD", minienv);
-	if (pwd && *pwd)
+	oldpwd = minienv_value("OLDPWD", minienv);
+	if (oldpwd && pwd && *pwd)
 		minienv_update("OLDPWD", pwd, minienv);
 	if (pwd && *pwd)
 		minienv_update("PWD", getcwd(cwd, PATH_MAX), minienv);

--- a/executes/get_path.c
+++ b/executes/get_path.c
@@ -29,16 +29,6 @@ static int	is_path(char *command)
 	return (FALSE);
 }
 
-static int	is_on_current_dir(char *command)
-{
-	char	current_path[PATH_MAX];
-	char	cwd[PATH_MAX];
-
-	getcwd(cwd, PATH_MAX);
-	create_path(current_path, cwd, "/", command);
-	return (access(current_path, F_OK) == 0);
-}
-
 static char	*local_path(char *command, t_env *minienv)
 {
 	char	full_path[PATH_MAX];
@@ -73,7 +63,5 @@ char	*get_path(char *command, t_env *minienv)
 		paths++;
 	}
 	free_array(paths_start);
-	if (is_on_current_dir(command))
-		return (local_path(command, minienv));
 	return (NULL);
 }

--- a/executes/get_path.c
+++ b/executes/get_path.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   get_path.c                                         :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: lalex-ku <lalex-ku@42sp.org.br>            +#+  +:+       +#+        */
+/*   By: sguilher <sguilher@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/06/08 18:15:41 by sguilher          #+#    #+#             */
-/*   Updated: 2022/06/24 20:22:43 by lalex-ku         ###   ########.fr       */
+/*   Updated: 2022/06/26 23:15:21 by sguilher         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -27,6 +27,16 @@ static int	is_path(char *command)
 	if (command[0] == '.' && command[1] == '/')
 		return (TRUE);
 	return (FALSE);
+}
+
+static int	is_on_current_dir(char *command)
+{
+	char	current_path[PATH_MAX];
+	char	cwd[PATH_MAX];
+
+	getcwd(cwd, PATH_MAX);
+	create_path(current_path, cwd, "/", command);
+	return (access(current_path, F_OK) == 0);
 }
 
 static char	*local_path(char *command, t_env *minienv)
@@ -63,5 +73,7 @@ char	*get_path(char *command, t_env *minienv)
 		paths++;
 	}
 	free_array(paths_start);
+	if (is_on_current_dir(command))
+		return (local_path(command, minienv));
 	return (NULL);
 }

--- a/expansions/expand_variables.c
+++ b/expansions/expand_variables.c
@@ -44,8 +44,12 @@ static void	update_input(char **input, char *var_value, char *second_part)
 	char	*first_part;
 	char	*updated_input;
 
-	if (!var_value)
-		first_part = ft_strjoin(*input, "");
+	if (!*input[0] && !var_value)
+		first_part = ft_strdup("");
+	else if (!*input[0] && var_value)
+		first_part = ft_strdup(var_value);
+	else if (!var_value)
+		first_part = ft_strdup(*input);
 	else
 		first_part = ft_strjoin(*input, var_value);
 	updated_input = ft_strjoin(first_part, second_part);

--- a/src/handle_heredoc.c
+++ b/src/handle_heredoc.c
@@ -73,6 +73,7 @@ void	read_heredoc(int *exit_status, t_env *minienv, char *delimiter,
 	close(tmp_file_fd);
 	free(delimiter);
 	free_minienv(&minienv);
+	rl_clear_history();
 	exit(EXIT_SUCCESS);
 }
 


### PR DESCRIPTION
cd:
- Add error msg for multiple args
- Add protection in case of zero args
- Change OLDPWD update only in case that OLDPWD exists (if we unset OLDPWD, when we use 'cd' the function was recreating the variable)
Leaks:
- Add rl_clear_history to heredoc read child process
- expansion variables: add protection in 'input_update' function when the input string begins with the variable (that exist or not)
Removes code for executes a binary file without './' (ex: only 'loop') according to workspaces behavior