### PR TITLE
Exit with plus sign

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ UTILS =		error.c quote_checker.c signals.c str_utils.c str_checkers.c \
 			get_label_name.c
 EXPANDS	= 	handle_expansions.c expand_variables.c expand_exit_status.c \
 			variables_utils.c
-LIBFT_A	=	./42-libraries/libft/libft.a
+LIBFT_A	=	./libft/libft.a
 HEADER	=	minishell.h allowed_libs.h builtins.h errors.h executes.h minienv.h
 VPATH	=	builtins minienv utils executes src redirects includes expansions \
 			syntax

--- a/builtins/exit.c
+++ b/builtins/exit.c
@@ -6,7 +6,7 @@
 /*   By: lalex-ku <lalex-ku@42sp.org.br>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/05/12 14:02:34 by lalex-ku          #+#    #+#             */
-/*   Updated: 2022/06/26 19:52:20 by lalex-ku         ###   ########.fr       */
+/*   Updated: 2022/06/26 20:06:26 by lalex-ku         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -65,7 +65,7 @@ int	builtin_exit(char **args, t_env **minienv)
 {
 	int	exit_status;
 
-	// rl_clear_history();
+	rl_clear_history();
 	free_minienv(minienv);
 	ft_putstr_fd("exit\n", STDOUT_FILENO);
 	check_args_error(args);

--- a/builtins/exit.c
+++ b/builtins/exit.c
@@ -6,7 +6,7 @@
 /*   By: lalex-ku <lalex-ku@42sp.org.br>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/05/12 14:02:34 by lalex-ku          #+#    #+#             */
-/*   Updated: 2022/06/24 20:26:44 by lalex-ku         ###   ########.fr       */
+/*   Updated: 2022/06/26 19:52:20 by lalex-ku         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -22,7 +22,7 @@ int	fits_in_long_long(char *str)
 	if (ft_strncmp(str, "-9223372036854775808", 21) == 0)
 		return (1);
 	out = 0;
-	if (*str == '-')
+	if (*str == '-' || *str == '+')
 		str++;
 	while (*str)
 	{
@@ -65,7 +65,7 @@ int	builtin_exit(char **args, t_env **minienv)
 {
 	int	exit_status;
 
-	rl_clear_history();
+	// rl_clear_history();
 	free_minienv(minienv);
 	ft_putstr_fd("exit\n", STDOUT_FILENO);
 	check_args_error(args);


### PR DESCRIPTION
Adicionei esses testes no tester também, o exit aceita um `+` na frente -> https://github.com/LucasKuhn/minishell_tester/commit/eb30887a7a397bd20c22b664da4161f879614b35

<img width="665" alt="image" src="https://user-images.githubusercontent.com/26127185/175837222-cf369481-6254-4d69-a0e6-8a83a960212e.png">

Tirei também o `42-libraries` do Makefile que ele tava dando relink e sempre tentando recompilar a libft 😅